### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM python:3.6.15-slim-bullseye as s3-tests
+WORKDIR /s3-tests
+COPY . /s3-tests
+RUN pip3 install -r requirements.txt

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+image:
+	@docker build -f Dockerfile -t s3-tests .

--- a/NEOFS_README.md
+++ b/NEOFS_README.md
@@ -1,3 +1,4 @@
+## Local run
 To start S3 compatibility tests do the following steps:
 1. Make sure `python 3.6` is installed:
 ```bash
@@ -164,3 +165,24 @@ KC_REALM=<name of the realm>
     ```
 Also, if you don't want to see all debug output you can append a parameter `--logging-level=ERROR`.  For more info see [here](https://nose.readthedocs.io/en/latest/usage.html).
 
+## Docker run
+
+In case of issues with environment setup, run tests from Docker environment. 
+To build an image use Makefile.
+
+```bash
+make image
+```
+
+It builds `s3-tests` image. Prepare config file as described above and run 
+`nosetests` in this container.
+
+```bash
+docker run \
+  -v `pwd`/your.conf:/s3-tests/s3tests.conf \
+  -e S3TEST_CONF=/s3-tests/s3tests.conf \
+  --network host \
+  -it s3-tests nosetests -v --nologcapture s3tests_boto3.functional
+```
+
+Specify correct configuration file path and network settings.


### PR DESCRIPTION
Tested in a local S3 Gateway deployment. Specify proper network if S3 Gateway runs in docker.

```
$ ls s3tests.conf
s3tests.conf

$ docker run   -v `pwd`/s3tests.conf:/s3-tests/s3tests.conf -e S3TEST_CONF=/s3-tests/s3tests.conf \
--network host -it s3-tests \
nosetests -v --nologcapture s3tests_boto3.functional

/usr/local/lib/python3.6/site-packages/boto3/compat.py:88: PythonDeprecationWarning: Boto3 will no 
longer support Python 3.6 starting May 30, 2022. To continue receiving service updates, bug fixes,
and security updates please upgrade to Python 3.7 or later. More information can be 
found here: https://aws.amazon.com/blogs/developer/python-support-policy-updates-for-aws-sdks-and-tools/
  warnings.warn(warning, PythonDeprecationWarning)
s3tests_boto3.functional.test_headers.test_object_create_bad_md5_invalid_short ... FAIL
s3tests_boto3.functional.test_headers.test_object_create_bad_md5_bad ... FAIL
...
```