### PR TITLE
Fix Typo test_s3.py

### DIFF
--- a/s3tests_boto3/functional/test_s3.py
+++ b/s3tests_boto3/functional/test_s3.py
@@ -5693,7 +5693,6 @@ def test_bucket_acl_no_grants():
     check_access_denied(client.put_object, Bucket=bucket_name, Key='baz', Body='a')
 
     #TODO fix this test once a fix is in for same issues in
-@attr('sanity')
     # test_access_bucket_private_object_private
     client2 = get_client()
     # owner can read acl


### PR DESCRIPTION
Fixed typo. The line was added by mistake at this position in a previous commit.