### PR TITLE
Add put object delay for some tests

### DIFF
--- a/s3tests_boto3/functional/test_s3.py
+++ b/s3tests_boto3/functional/test_s3.py
@@ -9184,6 +9184,7 @@ def create_multiple_versions(
 
         contents.append(body)
         version_ids.append(version_id)
+        time.sleep(1)
 
     #    if check_versions:
     #        check_obj_versions(client, bucket_name, key, version_ids, contents)
@@ -9554,6 +9555,7 @@ def test_versioning_obj_list_marker():
 
         contents.append(body)
         version_ids.append(version_id)
+        time.sleep(1)
 
     # for key #2
     for i in range(num_versions):
@@ -9563,6 +9565,7 @@ def test_versioning_obj_list_marker():
 
         contents2.append(body)
         version_ids2.append(version_id)
+        time.sleep(1)
 
     response = client.list_object_versions(Bucket=bucket_name)
     versions = response["Versions"]

--- a/s3tests_boto3/functional/test_s3_neofs.py
+++ b/s3tests_boto3/functional/test_s3_neofs.py
@@ -943,9 +943,11 @@ def test_object_versioning_workflow():
 
     response = client.put_object(Bucket=bucket_name, Key=object_name, Body="version1")
     assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
+    time.sleep(1)
 
     response = client.put_object(Bucket=bucket_name, Key=object_name, Body="version2")
     assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
+    time.sleep(1)
 
     response = client.delete_object(Bucket=bucket_name, Key=object_name)
     assert response["ResponseMetadata"]["HTTPStatusCode"] == 204


### PR DESCRIPTION
This delay is a temporary solution. It required to be able to get the right order of objects. There is some limitation to understand what object was first in the same second. See https://github.com/nspcc-dev/neofs-s3-gw/pull/1066.